### PR TITLE
Moya Work

### DIFF
--- a/uoit-directory/index.html
+++ b/uoit-directory/index.html
@@ -3802,52 +3802,57 @@
 									<br/>
 									<p>If you are a Faculty or Staff member you can have your directory information updated by filling out the form below.</p>
 									<!-- FORM INPUT FIELDS -->
-									<form data-abide>
+									<form data-abide novalidate>
+										<!-- ERROR MESSAGE FOR USER -->
+										<div data-abide-error class="alert callout" style="display: none;">
+											<p><i class="fi-alert"></i> There appears to be errors in your form.</p>
+										</div>
 										<div class="row">
 											<div class="small-12 medium-12 columns">
-												<label>BANNER USER ID:<b style="color:red"> *</b><input type="text" name="ID" required/></label>
+												<label>BANNER USER ID:<b style="color:red"> *</b><input type="text" name="id" required pattern="number"/></label>
 											</div>
 										</div>
 										<div class="row">
 											<div class="small-12 medium-6 columns">
-												<label>FIRST NAME:<b style="color:red"> *</b><input type="text" name="First Name" required/></label>
+												<label>FIRST NAME:<b style="color:red"> *</b><input type="text" name="firstName" required pattern="alpha"/></label>
 											</div>
 											<div class="small-12 medium-6 columns">
-												<label>LAST NAME:<b style="color:red"> *</b><input type="text" name="Last Name" required/></label>
-											</div>
-										</div>
-										<div class="row">
-											<div class="small-12 medium-6 columns">
-												<label>POSITION:<b style="color:red"> *</b><input type="text" name="Position" required/></label>
-											</div>
-											<div class="small-12 medium-6 columns">
-												<label>DEPARTMENT:<b style="color:red"> *</b><input type="text" name="Department" required/></label>
+												<label>LAST NAME:<b style="color:red"> *</b><input type="text" name="lastName" required pattern="alpha"/></label>
 											</div>
 										</div>
 										<div class="row">
 											<div class="small-12 medium-6 columns">
-												<label>EXTENSION:<b style="color:red"> *</b><input type="text" name="Extension" required/></label>
+												<label>DEPARTMENT:<b style="color:red"> *</b><input type="text" name="department" required pattern="alpha"/></label>
 											</div>
 											<div class="small-12 medium-6 columns">
-												<label>LOCATION:<b style="color:red"> *</b><input type="text" name="Location" required/></label>
+												<label>TITLE:<b style="color:red"> *</b><input type="text" name="position" required pattern="alpha"/></label>
 											</div>
 										</div>
 										<div class="row">
 											<div class="small-12 medium-6 columns">
-												<label>BUILDING:<b style="color:red"> *</b><input type="text" name="Building" required/></label>
+												<label>BUILDING:<b style="color:red"> *</b><input type="text" name="building" required/></label>
 											</div>
 											<div class="small-12 medium-6 columns">
-												<label>E-MAIL:<b style="color:red"> *</b><input type="text" name="E-mail" required/></label>
+												<label>OFFICE:<b style="color:red"> *</b><input type="text" name="location" required/></label>
+											</div>
+										</div>
+										<div class="row">
+											<div class="small-12 medium-6 columns">
+												<label>EXTENSION:<b style="color:red"> *</b><input type="text" name="extension" required pattern="number"/></label>
+											</div>
+											<div class="small-12 medium-6 columns">
+												<label>E-MAIL:<b style="color:red"> *</b><input type="text" name="email" required pattern="email"/></label>
 											</div>
 										</div>
 										<!-- SUBMIT BUTTON -->
-										<a data-open="exampleModal1" role="button" aria-label="submit form" class="button">SUBMIT</a>
+										<fieldset class="large-6 columns">
+											<button class="button" type="submit" value="Submit">Submit</button>
+										</fieldset>
 									</form>
 								</div>
 
 							</div>
 							<!-- tabs content end -->
-
 
 
 							<!-- SEARCH FILTER JSON FILE  -->
@@ -3889,8 +3894,8 @@
 														</a>
 														<div class="a-content" ng-class="{ 'hidden': ! showDetails }" data-tab-content>
 															<ul class='search-list-info'>
-																<li><b>Location: </b>{{x.dirschl_school_name }}</li>
-																<li><b>Building: </b>{{x.dirbuilding_building_name}}</li>
+																<li><b>Building: </b>{{x.dirbuilding_building_name }}</li>
+																<li><b>Office: </b>{{x.dirpepl_office}}</li>
 																<li><b>Extension: </b>{{x.dirpepl_extension}}</li>
 																<li><b>E-mail: </b>{{x.email}}</li>
 															</ul>
@@ -3938,16 +3943,6 @@
 							<a class="button green icon_map" href="buttons.php" onclick="">Campus Map</a>
 						</div>
 					</section>
-
-					<!-- UPDATE SUBMIT - THANK YOU MESSAGE -->
-					<div class="reveal" id="exampleModal1" data-reveal>
-						<h1>Thank you!</h1>
-						<p class="lead">Your update request has been sent!</p>
-						<p>Note: Your request won't be changed right away.</p>
-						<button class="close-button" data-close aria-label="Close modal" type="button">
-							<span aria-hidden="true">&times;</span>
-						</button>
-					</div>
 
 				</div>
 				<!-- /.page-row -->


### PR DESCRIPTION
- errors if fields are not filled out
- order of fields match the order of the tabs
- ‘position’ changes to ‘title’ on form
- ‘location’ changed to ’office’
(made more sense - thoughts?)
- banner id/extension requires numbers in field
- first name/last name/department requires alpha in field (believe
that’s for text)
- email requires email in field
- fixed data showing in search list results (location/office had school
name not office location)