### PR TITLE
Moya Work

### DIFF
--- a/uoit-directory/assets/js/app.js
+++ b/uoit-directory/assets/js/app.js
@@ -17,3 +17,10 @@ $(document)
 .bind("formvalid.zf.abide", function(e,$form) {
   // ajax submit
 });
+
+// smooth scroll to top of ‘Directory Search Results’
+$(".scrollTop").click(function() {
+    $('html,body').animate({
+        scrollTop: $("#angularSearch").offset().top},
+        'slow');
+});

--- a/uoit-directory/index.html
+++ b/uoit-directory/index.html
@@ -3511,11 +3511,10 @@
 											<div class="small-12 medium-3 columns">
 												<label>Department:</label><input type='text' ng-model='searchName.dirschl_school_name' ng-change='currentPage = 0' />
 											</div>
-											<div class="small-12 medium-3 small-centered text-center columns">
+											<!-- <div class="small-12 medium-3 small-centered text-center columns">
 												<a role="button" aria-label="search" class="button">SEARCH</a>
-											</div>
+											</div> -->
 										</div>
-										<!-- <a role="button" aria-label="search" class="button">SEARCH</a> -->
 									</form>
 								</div>
 								<!-- TAB 1 END  -->
@@ -3846,7 +3845,7 @@
 										</div>
 										<!-- SUBMIT BUTTON -->
 										<fieldset class="large-6 columns">
-											<button class="button" type="submit" value="Submit">Submit</button>
+											<button class="button" type="submit" value="Submit" role="button">Submit</button>
 										</fieldset>
 									</form>
 								</div>
@@ -3906,7 +3905,7 @@
 											<!-- PAGINATION - FUNCTIONAL -->
 											<ul class="pagination text-center" role="navigation" aria-label="Pagination" ng-hide="(currentPage + 1) > numberOfPages()">
 												<li class="pagination-previous">
-													<button role="button" ng-disabled="currentPage == 0" ng-click="currentPage=currentPage-1">
+													<button role="button" ng-disabled="currentPage == 0" ng-click="currentPage=currentPage-1" class="scrollTop">
 											        <span class="icon_arrow_left"></span> Previous
 											    </button>
 												</li>
@@ -3916,7 +3915,7 @@
 													</button>
 												</li>
 												<li class="pagination-next">
-													<button role="button" ng-disabled="(currentPage + 1) >= numberOfPages()" ng-click="currentPage=currentPage+1">
+													<button role="button" ng-disabled="(currentPage + 1) >= numberOfPages()" ng-click="currentPage=currentPage+1" class="scrollTop">
 															Next <span class="icon_arrow_right"></span>
 													</button>
 												</li>


### PR DESCRIPTION
- smooth scroll to top of ‘Directory Search Results’ when the ‘next’ or
‘previous’ pagination is clicked
- done in jQuery, but could be done in angular (thoughts?)
- search button removed in search tab because button does nothing.
(Should we put it back in or no?)